### PR TITLE
feat: PHP Application Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ end
 | `default['newrelic_install']['tags']` | `{}` | key value pair tags added through custom attributes |
 | `default['newrelic_install']['timeout_seconds']` | `600` | Sets timeout for installation task. |
 
+#### PHP Agent
+
+| Name | Default value | Description |
+|:-----|:--------------|:------------|
+| `default['newrelic_install']['env']['NEW_RELIC_APPLICATION_NAME']` | `nil` | optional name for your php application |
+
 ### Testing
 
 Refer to [testing](https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,4 +41,5 @@ default['newrelic_install']['timeout_seconds'] = '600'
 # PHP AGENT #
 #############
 
+# optional name for your php application
 default['newrelic_install']['env']['NEW_RELIC_APPLICATION_NAME'] = ''

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,7 +23,7 @@ default['newrelic_install']['verbosity'] = ''
 # infrastructure-agent-installer
 # logs-integration
 # php-agent-installer
-default['newrelic_install']['targets'] = Set[]
+default['newrelic_install']['targets'] = []
 
 ########
 # TAGS #
@@ -36,3 +36,9 @@ default['newrelic_install']['tags'] = {}
 ################
 
 default['newrelic_install']['timeout_seconds'] = '600'
+
+#############
+# PHP AGENT #
+#############
+
+default['newrelic_install']['env']['NEW_RELIC_APPLICATION_NAME'] = ''

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ license 'All Rights Reserved'
 description 'Installs/Configures Newrelic agents using guided install through chef'
 source_url        'https://github.com/newrelic/chef-install'
 issues_url        'https://github.com/newrelic/chef-install/issues'
-version '0.1.9'
+version '0.1.10'
 chef_version '>= 15.0'
 
 # Platform support


### PR DESCRIPTION
Adds the option of naming the deployed PHP Application. Also fixes an error encountered when using a Set to define target names in attributes.