### PR TITLE
docs(chef-cookbook): Add steps to add a new target agent in chef

### DIFF
--- a/developers-guide.md
+++ b/developers-guide.md
@@ -1,4 +1,4 @@
-## Add a New Target to the Chef Cookbook
+# Add a New Target to the Chef Cookbook
 
 This guide is for developers who want to add support for a new target in the `newrelic_install` cookbook.
 
@@ -36,9 +36,23 @@ This guide is for developers who want to add support for a new target in the `ne
     cd chef-install
     ```
 
-- **Add target agent name in `resources/newrelic_install.rb` and `attributes/default.rb`:**
-    
-  ![image](https://github.com/user-attachments/assets/d4a7e5e1-4b4e-4758-8543-9adb5328e363)
+- **Add target agent name in `resources/newrelic_install.rb`:**
+
+  **Note:** The installer names can be found in the recipes of the [open-install-library](https://github.com/newrelic/open-install-library) repository.
+
+  **Example: Adding Support for Java Agent:**
+  - First, retrieve the agent installer name from the [Node](https://github.com/newrelic/open-install-library/blob/main/recipes/newrelic/apm/node/linux.yml) recipe.
+    All agent recipes can be found in `recipes/newrelic` directory.
+    The `name` attribute at the top of the .yml file (e.g., `linux.yml`) corresponds to the agent installer name needed for the `allowed_targets`.
+
+    ![image](https://github.com/user-attachments/assets/7c64ebc2-00ae-4af7-b620-14059fbf2085)
+
+  - After retrieving the installer name, add it to the `allowed_targets` in `resources/newrelic_install.rb`.
+    From the previous example, updated `allowed_targets` for the Node agent will look like this:
+
+    ![image](https://github.com/user-attachments/assets/d4a7e5e1-4b4e-4758-8543-9adb5328e363)
+
+- **Add target agent name in `attributes/default.rb`:**
 
   ![image](https://github.com/user-attachments/assets/56ce960f-d2ab-4632-91bd-06033633b393)
 

--- a/developers-guide.md
+++ b/developers-guide.md
@@ -71,6 +71,11 @@ This guide is for developers who want to add support for a new target in the `ne
     chef-client -z -r "recipe[chef-install::default]"
     ```
 
+    **Note: Upon executing the above command, the cookbook will utilize the New Relic CLI to perform target installations included in `attributes/default.rb`. All targets in this cookbook depend on the New Relic CLI for installation.**
+
+    ![image](https://github.com/user-attachments/assets/36204f9c-f541-4482-8ebc-3d553b90f320)
+
+
 **Note: If you are a developer who want to add support for a new target agent in the `newrelic_install` cookbook, the instructions in this guide for adding a new target agent support will only modify the local copy of the `newrelic_install` cookbook.**
 
 **To make these changes live, you will need to:**

--- a/developers-guide.md
+++ b/developers-guide.md
@@ -60,7 +60,7 @@ This guide is for developers who want to add support for a new target in the `ne
 
 - **Configure `attributes/default.rb`**
 
-    Add the target agent name to the targets attribute (include any environment variables required by the agent). For more information on enviroment variables, please refer to [newrelic docs](https://docs.newrelic.com/).
+    Add the target agent name to the targets attribute and include any environment variables required by the agent (Note: To locate the environment variables for a specific agent, please refer to the configuration section of the specific [agent](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/introduction-apm/) documentation).
   
   ![image](https://github.com/user-attachments/assets/2c94eaac-16ea-444a-b2ba-61e7d685a8f3)
 

--- a/developers-guide.md
+++ b/developers-guide.md
@@ -2,7 +2,7 @@
 
 This guide is for developers who want to add support for a new target in the `newrelic_install` cookbook.
 
-### 1. Setup Workstation
+### Step 1: Setup Workstation
 
 - **Download and Install Chef Workstation**
 
@@ -28,7 +28,7 @@ This guide is for developers who want to add support for a new target in the `ne
   chef -v
   ```
 
-### 2. Add target to `chef-install` repository
+### Step 2: Add target to `chef-install` repository
 
 - **Clone `chef-install` repository:**
     ```bash
@@ -36,11 +36,11 @@ This guide is for developers who want to add support for a new target in the `ne
     cd chef-install
     ```
 
-- **Add target agent name in `resources/newrelic_install.rb`:**
+- **Add target agent name in `chef-install`:**
 
   **Note:** The installer names can be found in the recipes of the [open-install-library](https://github.com/newrelic/open-install-library) repository.
 
-  **Example: Adding Support for Java Agent:**
+  **Example: Adding Support for Node Agent:**
   - First, retrieve the agent installer name from the [Node](https://github.com/newrelic/open-install-library/blob/main/recipes/newrelic/apm/node/linux.yml) recipe.
     All agent recipes can be found in `recipes/newrelic` directory.
     The `name` attribute at the top of the .yml file (e.g., `linux.yml`) corresponds to the agent installer name needed for the `allowed_targets`.
@@ -52,13 +52,18 @@ This guide is for developers who want to add support for a new target in the `ne
 
     ![image](https://github.com/user-attachments/assets/d4a7e5e1-4b4e-4758-8543-9adb5328e363)
 
-- **Add target agent name in `attributes/default.rb`:**
+  - **Add target agent name in `attributes/default.rb`:**
 
-  ![image](https://github.com/user-attachments/assets/56ce960f-d2ab-4632-91bd-06033633b393)
+    ![image](https://github.com/user-attachments/assets/8cfe577e-8ae7-4939-bc56-4386e6b9dcb2)
 
-### 3. Test Changes Locally
+### Step 3: Testing the target locally
 
-- Before testing the changes, make sure the required environment variables such as API keys and targeted installs are configured properly in `attributes/default.rb`
+- **Configure `attributes/default.rb`**
+
+    Add the target agent name to the targets attribute (include any environment variables required by the agent). For more information on enviroment variables, please refer to [newrelic docs](https://docs.newrelic.com/).
+  
+  ![image](https://github.com/user-attachments/assets/2c94eaac-16ea-444a-b2ba-61e7d685a8f3)
+
 - To test your changes locally, execute the following command:
   
     ```bash
@@ -66,3 +71,9 @@ This guide is for developers who want to add support for a new target in the `ne
     chef-client -z -r "recipe[chef-install::default]"
     ```
 
+**Note: If you are a developer who want to add support for a new target agent in the `newrelic_install` cookbook, the instructions in this guide for adding a new target agent support will only modify the local copy of the `newrelic_install` cookbook.**
+
+**To make these changes live, you will need to:**
+- **Create a pull request ([reference PR](https://github.com/newrelic/chef-install/pull/17)) with your modifications.**
+- **Once the PR is merged, the changes will be released.**
+- **After the changes are merged and released, the `newrelic_install` cookbook will be updated on Chef Supermarket.**

--- a/developers-guide.md
+++ b/developers-guide.md
@@ -78,7 +78,7 @@ This guide is for developers who want to add support for a new target in the `ne
 
 **Note: If you are a developer who want to add support for a new target agent in the `newrelic_install` cookbook, the instructions in this guide for adding a new target agent support will only modify the local copy of the `newrelic_install` cookbook.**
 
-**To make these changes live, you will need to:**
-- **Create a pull request ([reference PR](https://github.com/newrelic/chef-install/pull/17)) with your modifications.**
-- **Once the PR is merged, the changes will be released.**
-- **After the changes are merged and released, the `newrelic_install` cookbook will be updated on Chef Supermarket.**
+To make these changes live, you will need to:
+- Create a pull request ([reference PR](https://github.com/newrelic/chef-install/pull/17)) with your modifications.
+- Once the PR is merged, the changes will be released.
+- After the changes are merged and released, the `newrelic_install` cookbook will be updated on Chef Supermarket.

--- a/developers-guide.md
+++ b/developers-guide.md
@@ -1,0 +1,54 @@
+## Add a New Target to the Chef Cookbook
+
+This guide is for developers who want to add support for a new target in the `newrelic_install` cookbook.
+
+### 1. Setup Workstation
+
+- **Download and Install Chef Workstation**
+
+    Download the Chef Workstation source file based on your operating system. For different releases or earlier versions, visit the [Chef Workstation Downloads page](https://www.chef.io/downloads). For detailed installation instructions, refer to the [Chef Workstation Installation Documentation](https://docs.chef.io/workstation/install_workstation/).
+
+- **Download the Chef Workstation package:**
+  ```bash
+  wget https://packages.chef.io/files/stable/chef-workstation/22.10.1013/ubuntu/20.04/chef-workstation_22.10.1013-1_amd64.deb
+  ```
+
+- **Install the Chef Workstation package:**
+  ```bash
+  sudo dpkg -i chef-workstation_*.deb
+  ```
+
+- **Remove the source file:**
+  ```bash
+  rm chef-workstation_*.deb
+  ```
+
+- **Verify installation:**
+  ```bash
+  chef -v
+  ```
+
+### 2. Add target to `chef-install` repository
+
+- **Clone `chef-install` repository:**
+    ```bash
+    git clone https://github.com/newrelic/chef-install.git
+    cd chef-install
+    ```
+
+- **Add target agent name in `resources/newrelic_install.rb` and `attributes/default.rb`:**
+    
+  ![image](https://github.com/user-attachments/assets/d4a7e5e1-4b4e-4758-8543-9adb5328e363)
+
+  ![image](https://github.com/user-attachments/assets/56ce960f-d2ab-4632-91bd-06033633b393)
+
+### 3. Test Changes Locally
+
+- Before testing the changes, make sure the required environment variables such as API keys and targeted installs are configured properly in `attributes/default.rb`
+- To test your changes locally, execute the following command:
+  
+    ```bash
+    cd chef-install
+    chef-client -z -r "recipe[chef-install::default]"
+    ```
+


### PR DESCRIPTION
### Description

This PR aims to create developers-guide to add a new target agent to chef-install.