### PR TITLE
chore(version): bump to 0.1.14

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ license 'All Rights Reserved'
 description 'Installs/Configures Newrelic agents using guided install through chef'
 source_url        'https://github.com/newrelic/chef-install'
 issues_url        'https://github.com/newrelic/chef-install/issues'
-version '0.1.13'
+version '0.1.14'
 chef_version '>= 15.0'
 
 # Platform support


### PR DESCRIPTION
## Summary

Bumps `metadata.rb` from `0.1.13` to `0.1.14`.

Earlier the Release workflow ([run #27266540824](https://github.com/newrelic/chef-install/actions/runs/27266540824)) failed with `ERROR: Version has already been taken` because Chef Supermarket already has `0.1.13` published — `metadata.rb` needs to be ahead of Supermarket before `knife supermarket share` will accept the upload.

## Test plan

- [ ] Merge.
- [ ] Re-run the Release workflow on `main` — should publish `0.1.14` to Supermarket.