### PR TITLE
fix(security): add explicit workflow permissions to ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,16 @@ name: ci
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   rspec:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

Resolves the 3 open CodeQL `actions/missing-workflow-permissions` alerts on `.github/workflows/main.yml` (rspec, cookstyle, yamllint jobs).

- Workflow-level: `contents: read` (minimal default).
- `rspec` job: `contents: read` + `checks: write` + `pull-requests: write` so `SonicGarden/rspec-report-action` can post the check run and PR comment.
- `cookstyle` and `yamllint` inherit the read-only workflow default — they only check out code.

`release.yml` already has `permissions: write-all` and was not flagged by CodeQL, so it's untouched here.

## Test plan

- [ ] CodeQL re-scan closes alerts #1, #2, #3 after merge.
- [ ] CI on this PR (rspec + cookstyle + yamllint) still passes — proves the permission set is correct.