### PR TITLE
chore(version): bump to 0.1.15

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ license 'All Rights Reserved'
 description 'Installs/Configures Newrelic agents using guided install through chef'
 source_url        'https://github.com/newrelic/chef-install'
 issues_url        'https://github.com/newrelic/chef-install/issues'
-version '0.1.14'
+version '0.1.15'
 chef_version '>= 15.0'
 
 # Platform support


### PR DESCRIPTION
## Summary

Bumps `metadata.rb` from `0.1.14` to `0.1.15` so the next `workflow_dispatch` of the Release workflow publishes cleanly to Chef Supermarket.

`0.1.14` is already the latest published version on Supermarket — without this bump, `knife supermarket share newrelic-install` would fail with `ERROR: Version has already been taken` (same failure mode as the earlier 0.1.13 → 0.1.14 bump).

## Test plan

- [ ] Merge.
- [ ] Re-dispatch the Release workflow on `main` — should publish `0.1.15` to Supermarket.