### PR TITLE
feat(targets): add NRDOT MSSQL and Oracle collector targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ end
 |:------------------------------------------------------|:--------------|:----------------------------------------------------------------------------------------------------------------------------------------------------|
 | `default['newrelic_install']['NEW_RELIC_API_KEY']`    | `nil`         | new relic api key                                                                                                                                   |
 | `default['newrelic_install']['NEW_RELIC_ACCOUNT_ID']` | `nil`         | new relic account id                                                                                                                                |
-| `default['newrelic_install']['targets']`              | []            | agents to be installed, possible values are (`infrastructure-agent-installer`, `logs-integration`, `php-agent-installer`, `dotnet-agent-installer`) |
+| `default['newrelic_install']['targets']`              | []            | agents to be installed, possible values are (`infrastructure-agent-installer`, `logs-integration`, `php-agent-installer`, `dotnet-agent-installer`, `agent-control`, `logs-integration-agent-control`, `nrdot-collector-mssql`, `nrdot-collector-mssql-winauth`, `nrdot-collector-mssql-rds`, `nrdot-collector-mssql-rds-winauth`, `nrdot-collector-oracle`, `nrdot-collector-oracle-rds`) |
 
 #### Optional
 
@@ -87,6 +87,10 @@ end
 | Name                                                               | Default value | Description                               |
 |:-------------------------------------------------------------------|:--------------|:------------------------------------------|
 | `default['newrelic_install']['env']['NEW_RELIC_APPLICATION_NAME']` | `nil`         | optional name for your dotnet application |
+
+#### NRDOT MSSQL / Oracle Collectors
+
+The `nrdot-collector-mssql*` and `nrdot-collector-oracle*` targets each require their own set of `NR_CLI_*` env vars (server/host, port, credentials, auth mode) that vary by variant (local vs RDS, SQL auth vs Windows/gMSA auth). No defaults are declared for these — set the vars relevant to your chosen target via `default['newrelic_install']['env'][...]`. See the comments in `attributes/default.rb` and the corresponding recipe definitions in [open-install-library](https://github.com/newrelic/open-install-library) for the exact list per target.
 
 ### Testing
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,12 @@ default['newrelic_install']['verbosity'] = ''
 # dotnet-agent-installer
 # agent-control
 # logs-integration-agent-control
+# nrdot-collector-mssql
+# nrdot-collector-mssql-winauth
+# nrdot-collector-mssql-rds
+# nrdot-collector-mssql-rds-winauth
+# nrdot-collector-oracle
+# nrdot-collector-oracle-rds
 default['newrelic_install']['targets'] = []
 
 ########
@@ -46,3 +52,33 @@ default['newrelic_install']['timeout_seconds'] = '600'
 
 # optional name for your application
 default['newrelic_install']['env']['NEW_RELIC_APPLICATION_NAME'] = ''
+
+#######################
+# NRDOT MSSQL, ORACLE #
+#######################
+
+# These targets require env vars that vary by variant (local vs RDS, auth
+# mode) and often include credentials, so no defaults are declared here.
+# Set only the vars needed for your chosen target via env attribute overrides.
+#
+# nrdot-collector-mssql / nrdot-collector-mssql-rds:
+#   NR_CLI_MSSQL_CONFIG_PRESET, NR_CLI_MSSQL_SERVER, NR_CLI_MSSQL_PORT,
+#   NR_CLI_MSSQL_LOGIN_NAME, NR_CLI_MSSQL_SA_PASSWORD (local) or
+#   NR_CLI_MSSQL_MASTER_USER / NR_CLI_MSSQL_MASTER_PASSWORD (RDS)
+#
+# nrdot-collector-mssql-winauth / nrdot-collector-mssql-rds-winauth:
+#   NR_CLI_MSSQL_AUTH_MODE, NR_CLI_MSSQL_WIN_ACCOUNT, NR_CLI_MSSQL_WIN_PASSWORD,
+#   NR_CLI_MSSQL_GMSA_ACCOUNT (plus server/port/preset above)
+#
+# nrdot-collector-oracle:
+#   NR_CLI_ORACLE_CONFIG_PRESET, NR_CLI_ORACLE_HOST, NR_CLI_ORACLE_PORT,
+#   NR_CLI_ORACLE_CONTAINER_TYPE, NR_CLI_ORACLE_PDB_NAME, NR_CLI_ORACLE_SSH_USER,
+#   NR_CLI_ORACLE_LOGIN_NAME, NR_CLI_ORACLE_LOGIN_PASSWORD, NR_CLI_ORACLE_SERVICE_NAME
+#
+# nrdot-collector-oracle-rds:
+#   NR_CLI_ORACLE_CONFIG_PRESET, NR_CLI_ORACLE_HOST, NR_CLI_ORACLE_PORT,
+#   NR_CLI_ORACLE_ADMIN_USER, NR_CLI_ORACLE_ADMIN_PASSWORD, NR_CLI_ORACLE_LOGIN_NAME,
+#   NR_CLI_ORACLE_LOGIN_PASSWORD, NR_CLI_ORACLE_SERVICE_NAME
+#
+# See https://github.com/newrelic/open-install-library/pull/1403, #1412, #1416
+# for the authoritative recipe definitions (open at time of writing).

--- a/resources/newrelic_install.rb
+++ b/resources/newrelic_install.rb
@@ -72,6 +72,12 @@ action_class do
       dotnet-agent-installer
       agent-control
       logs-integration-agent-control
+      nrdot-collector-mssql
+      nrdot-collector-mssql-winauth
+      nrdot-collector-mssql-rds
+      nrdot-collector-mssql-rds-winauth
+      nrdot-collector-oracle
+      nrdot-collector-oracle-rds
     ).to_set
     allowed_targets_string = allowed_targets.join(', ')
     incoming_targets = new_resource.targets.to_set

--- a/spec/unit/resources/newrelic_install_spec.rb
+++ b/spec/unit/resources/newrelic_install_spec.rb
@@ -290,4 +290,70 @@ describe 'newrelic-install::default' do
       expect(subject).not_to run_powershell_script('newrelic install').with(code: include('logs-integration-agent-control'))
     end
   end
+
+  context 'when targets only contains nrdot-collector-mssql' do
+    default_attributes['newrelic_install']['NEW_RELIC_API_KEY'] = 'xxx'
+    default_attributes['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = 'xxx'
+    default_attributes['newrelic_install']['NEW_RELIC_REGION'] = 'xxx'
+    default_attributes['newrelic_install']['targets'] = ['nrdot-collector-mssql']
+
+    it 'run bash newrelic install command with nrdot-collector-mssql' do
+      expect(subject).to run_execute('newrelic install').with(command: include('nrdot-collector-mssql'))
+    end
+  end
+
+  context 'when targets only contains nrdot-collector-mssql-winauth' do
+    default_attributes['newrelic_install']['NEW_RELIC_API_KEY'] = 'xxx'
+    default_attributes['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = 'xxx'
+    default_attributes['newrelic_install']['NEW_RELIC_REGION'] = 'xxx'
+    default_attributes['newrelic_install']['targets'] = ['nrdot-collector-mssql-winauth']
+
+    it 'run bash newrelic install command with nrdot-collector-mssql-winauth' do
+      expect(subject).to run_execute('newrelic install').with(command: include('nrdot-collector-mssql-winauth'))
+    end
+  end
+
+  context 'when targets only contains nrdot-collector-mssql-rds' do
+    default_attributes['newrelic_install']['NEW_RELIC_API_KEY'] = 'xxx'
+    default_attributes['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = 'xxx'
+    default_attributes['newrelic_install']['NEW_RELIC_REGION'] = 'xxx'
+    default_attributes['newrelic_install']['targets'] = ['nrdot-collector-mssql-rds']
+
+    it 'run bash newrelic install command with nrdot-collector-mssql-rds' do
+      expect(subject).to run_execute('newrelic install').with(command: include('nrdot-collector-mssql-rds'))
+    end
+  end
+
+  context 'when targets only contains nrdot-collector-mssql-rds-winauth' do
+    default_attributes['newrelic_install']['NEW_RELIC_API_KEY'] = 'xxx'
+    default_attributes['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = 'xxx'
+    default_attributes['newrelic_install']['NEW_RELIC_REGION'] = 'xxx'
+    default_attributes['newrelic_install']['targets'] = ['nrdot-collector-mssql-rds-winauth']
+
+    it 'run bash newrelic install command with nrdot-collector-mssql-rds-winauth' do
+      expect(subject).to run_execute('newrelic install').with(command: include('nrdot-collector-mssql-rds-winauth'))
+    end
+  end
+
+  context 'when targets only contains nrdot-collector-oracle' do
+    default_attributes['newrelic_install']['NEW_RELIC_API_KEY'] = 'xxx'
+    default_attributes['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = 'xxx'
+    default_attributes['newrelic_install']['NEW_RELIC_REGION'] = 'xxx'
+    default_attributes['newrelic_install']['targets'] = ['nrdot-collector-oracle']
+
+    it 'run bash newrelic install command with nrdot-collector-oracle' do
+      expect(subject).to run_execute('newrelic install').with(command: include('nrdot-collector-oracle'))
+    end
+  end
+
+  context 'when targets only contains nrdot-collector-oracle-rds' do
+    default_attributes['newrelic_install']['NEW_RELIC_API_KEY'] = 'xxx'
+    default_attributes['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = 'xxx'
+    default_attributes['newrelic_install']['NEW_RELIC_REGION'] = 'xxx'
+    default_attributes['newrelic_install']['targets'] = ['nrdot-collector-oracle-rds']
+
+    it 'run bash newrelic install command with nrdot-collector-oracle-rds' do
+      expect(subject).to run_execute('newrelic install').with(command: include('nrdot-collector-oracle-rds'))
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Adds 6 new install targets to `newrelic_install`'s allowlist: `nrdot-collector-mssql`,
  `nrdot-collector-mssql-winauth`, `nrdot-collector-mssql-rds`, `nrdot-collector-mssql-rds-winauth`,
  `nrdot-collector-oracle`, `nrdot-collector-oracle-rds`
- These correspond to the new NRDOT MSSQL/Oracle collector recipes from
  open-install-library PRs #1403, #1412, and #1416
- Documents the required `NR_CLI_*` env vars per target in `attributes/default.rb`
  (no defaults declared — values vary by auth mode/RDS-vs-local and include credentials)
- Updates README targets table and adds ChefSpec coverage for each new target

## Note
open-install-library PRs #1403, #1412, and #1416 are open/unmerged as of this PR.
Target strings were taken from their current diffs; if the recipe `name:` values
change before merge, this allowlist will need a follow-up update.